### PR TITLE
Make cURL's timeout and connect timeout configurable

### DIFF
--- a/Instaphp/Instaphp.php
+++ b/Instaphp/Instaphp.php
@@ -75,6 +75,7 @@ class Instaphp extends ContainerAware
       'version'=> 'v1',
       'endpoint'=> 'https://api.instagram.com',
       'endpoint_timeout'=> '10',
+      'endpoint_connect_timeout' => 2,
       'client_id'=> null,
       'client_secret'=> null,
       'oauth_path'=> '/oauth/authorize/?client_id={client_id}&amp;response_type=code&amp;redirect_uri={RedirectUri}',

--- a/Instaphp/WebRequest.php
+++ b/Instaphp/WebRequest.php
@@ -88,6 +88,9 @@ class WebRequest
 		if (isset($this->config['endpoint_timeout']))
 			$this->_options[CURLOPT_TIMEOUT] = $this->config['endpoint_timeout'];
 
+		if (isset($this->config['endpoint_connect_timeout']))
+			$this->_options[CURLOPT_CONNECTTIMEOUT] = $this->config['endpoint_connect_timeout'];
+
 		$this->_options[CURLOPT_USERAGENT] = 'Instaphp/' . $this->config['version'];
 
 		if(isset($this->config['no_verify_peer']))

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Add the following line to `app/config/config.yml`:
 	imports:
 		- { resource: @OhInstagramBundle/Resources/config/services.yml }
 
+Add the following config to your parameters.yml:
+
+    instagram_api_client_id: YOUR_API_ID
+    instagram_api_client_secret: YOUR_API_SECRET
+    instagram_timeout: 30
+    instagram_connect_timeout: 8
+
 And if you're OK with the provided routes, add these to `app/config/routing.yml`
 
     OhInstagramBundle:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,7 +7,8 @@ parameters:
     instaphp.config:
       version: v1
       endpoint: https://api.instagram.com
-      endpoint_timeout: 10
+      endpoint_timeout: %instagram_timeout%
+      endpoint_connect_timeout: %instagram_connect_timeout%
       client_id: %instagram_api_client_id%
       client_secret: %instagram_api_client_secret%
       scope: comments+likes+relationships


### PR DESCRIPTION
The less ideal but backwards-compatible and easier way.

Probably fixes ollietb/OhInstagramBundle#1 (try bumping both timeouts up - I had a similar error).
